### PR TITLE
Prototype update

### DIFF
--- a/JS_Timer.h
+++ b/JS_Timer.h
@@ -24,5 +24,5 @@ class JS_Timer {
         uint8_t setInterval(funcPointer, uint32_t);  // note function and durration to interval trigger
         uint8_t setTimeout(funcPointer, uint32_t);   // note function and durration to timeout trigger
     private:
-        byte addTimer(funcPointer, unsigned long, boolean);
+        byte addTimer(funcPointer, uint32_t, boolean);
 };


### PR DESCRIPTION
Changed addTimer prototype to use uint32_t instead of unsigned long

Maybe it's a compiler version thing, but Arduino 1.6.8 complained...
